### PR TITLE
Update Policies.json

### DIFF
--- a/jsons/Policies.json
+++ b/jsons/Policies.json
@@ -486,7 +486,7 @@
             {
                 "name": "Consulates",
                 "uniques": [
-                    "Resting point for Influence with City-States is increased by [20]",
+                    "Allied City-States will occasionally gift Great People",
                     "Provides [1] [Policies]"
                 ],
                 "requires": ["Cultural Diplomacy"],
@@ -496,11 +496,11 @@
             {
                 "name": "Patronage Complete",
                 "uniques": [
-                    "[+50]% [Culture] from City-States",
-                    "[+50]% [Faith] from City-States",
-                    "[+50]% [Food] from City-States",
-                    "[+50]% [Happiness] from City-States",
-                    "Allied City-States will occasionally gift Great People"
+                    "[+100]% [Culture] from City-States",
+                    "[+100]% [Faith] from City-States",
+                    "[+100]% [Food] from City-States",
+                    "[+100]% [Happiness] from City-States",
+                    "Militaristic City-States grant units [2] times as fast when you are at war with a common nation"
                 ]
             }
         ]


### PR DESCRIPTION
* Moved great person gifting to Consulates, to replace the old gimmick ability
* Added 2× military unit gifting to the finisher, as is Lek behaviour (although there it also applies when not at war)
* Increased the bonus from the finisher to +100%. During the discussion, it was deemed too little reward compared to the risk to go full Patronage, maybe this will fix it (if it turns out too strong, we could try +75%).