### PR TITLE
Constabulary: +1 эффективный ранг шпиона в контрразведке

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ Fork Rekmod with changes for the multiplayer games
 #### Building Changes
 - Hanse 25% -> 10%
 - BMPC Plant requires improved resource, provides 4 Oil
-- Constabulary / Convict Penitentiary: `Spies in [in this city] cities act as though they have [1] levels for [Counter-intelligence]` (requires Unciv with this unique)
+- Constabulary / Convict Penitentiary: `Spies in [in this city] cities act as though they have [+1] levels for [Counter-intelligence]` (requires Unciv with this unique)
 

--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ Fork Rekmod with changes for the multiplayer games
 #### Building Changes
 - Hanse 25% -> 10%
 - BMPC Plant requires improved resource, provides 4 Oil
-- Constabulary / Convict Penitentiary: counter-intelligence spies in the city gain +1 effective level (capped at maxSpyRank; requires Unciv with this unique)
+- Constabulary / Convict Penitentiary: `Spies in [in this city] cities act as though they have [1] levels for [Counter-intelligence]` (requires Unciv with this unique)
 

--- a/README.md
+++ b/README.md
@@ -19,4 +19,5 @@ Fork Rekmod with changes for the multiplayer games
 #### Building Changes
 - Hanse 25% -> 10%
 - BMPC Plant requires improved resource, provides 4 Oil
+- Constabulary / Convict Penitentiary: counter-intelligence spies in the city gain +1 effective level (capped at maxSpyRank; requires Unciv with this unique)
 

--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -2577,7 +2577,8 @@
         "hurryCostModifier": 25,
         "uniques": [
             "Only available <when espionage is enabled>",
-            "[-25]% enemy spy effectiveness [in this city]"
+            "[-25]% enemy spy effectiveness [in this city]",
+            "[1] level(s) for counter-intelligence spies [in this city]"
         ],
         "requiredTech": "Banking"
     },
@@ -2592,7 +2593,8 @@
         "percentStatBonus": {"gold": 5,"production": 5},
         "uniques": [
             "Only available <when espionage is enabled>",
-            "[-25]% enemy spy effectiveness [in this city]"
+            "[-25]% enemy spy effectiveness [in this city]",
+            "[1] level(s) for counter-intelligence spies [in this city]"
         ],
         "requiredTech": "Machinery"
     },

--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -2578,7 +2578,7 @@
         "uniques": [
             "Only available <when espionage is enabled>",
             "[-25]% enemy spy effectiveness [in this city]",
-            "[1] level(s) for counter-intelligence spies [in this city]"
+            "Spies in [in this city] cities act as though they have [1] levels for [Counter-intelligence]"
         ],
         "requiredTech": "Banking"
     },
@@ -2594,7 +2594,7 @@
         "uniques": [
             "Only available <when espionage is enabled>",
             "[-25]% enemy spy effectiveness [in this city]",
-            "[1] level(s) for counter-intelligence spies [in this city]"
+            "Spies in [in this city] cities act as though they have [1] levels for [Counter-intelligence]"
         ],
         "requiredTech": "Machinery"
     },

--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -2578,7 +2578,7 @@
         "uniques": [
             "Only available <when espionage is enabled>",
             "[-25]% enemy spy effectiveness [in this city]",
-            "Spies in [in this city] cities act as though they have [1] levels for [Counter-intelligence]"
+            "Spies in [in this city] cities act as though they have [+1] levels for [Counter-intelligence]"
         ],
         "requiredTech": "Banking"
     },
@@ -2594,7 +2594,7 @@
         "uniques": [
             "Only available <when espionage is enabled>",
             "[-25]% enemy spy effectiveness [in this city]",
-            "Spies in [in this city] cities act as though they have [1] levels for [Counter-intelligence]"
+            "Spies in [in this city] cities act as though they have [+1] levels for [Counter-intelligence]"
         ],
         "requiredTech": "Machinery"
     },


### PR DESCRIPTION
## Summary
- На `Constabulary` и австралийский `Convict Penitentiary` добавлен unique `[1] level(s) for counter-intelligence spies [in this city]`.
- Шпион в контрразведке в городе с жандармерией получает +1 к эффективному рангу (потолок 3★), не навсегда.
- Требует Unciv с поддержкой этого unique (см. PR в Unciv).

## Test plan
- [ ] Запустить игру с RekMOD-iron + Unciv с новым unique.
- [ ] Построить Constabulary, поставить шпиона в контрразведку — в UI 1★.
- [ ] Проверить, что без здания бонуса нет.
- [ ] Проверить Convict Penitentiary у Австралии.
