### PR TITLE
UA Аксума: мгновенная конвертация и без пассивного давления за рубеж

### DIFF
--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -57,11 +57,8 @@
         "innerColor": [190, 146, 61],
         "uniqueName": "Saint Elesbaan's Blessing",
         "uniques": [
-            // Something Something Religion goes to every city immedietely
-            // Something Something Religion doesn't spread to other cities
-            //Note: this requires a unique regarding what it spreads to, not from
-            //"[-999]% Natural religion spread [in enemy cities]",
-            //"[+10000]% Natural religion spread [in your cities] <for [2] turns> <upon founding a Religion>"
+            "All your cities convert to your religion when a religion is founded",
+            "No natural religion spread from your cities to foreign cities"
         ],
         "cities": [
             "Aksum","Adulis","Qohaito","Matara","Yeha","Hawulti","Massawa","Zeila","Lalibela","Addi Galamo",


### PR DESCRIPTION
## Кратко

- Включён UA Аксума «Saint Elesbaan's Blessing» через два новых unique Unciv.
- При основании религии все свои города сразу принимают её.
- Пассивное религиозное давление из городов Аксума не идёт в чужие города (миссионеры работают как обычно).

## Готовность к merge

- **Блокер (Unciv ещё open):** https://github.com/yairm210/Unciv/pull/15235 — до merge доработка не работает (unknown unique игнорируются); **не мержить** этот PR раньше.

## План проверки

- [ ] RekMOD-iron + Unciv с #15235 (или после его merge), Аксум, религия включена.
- [ ] Основать религию — все города Аксума сразу с этой религией.
- [ ] Соседние города других игроков не получают пассивное давление от городов Аксума.
- [ ] Миссионер Аксума по-прежнему может распространять веру.