### PR TITLE
Constabulary: +1 к counter-intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ Fork Rekmod with changes for the multiplayer games
 #### Building Changes
 - Hanse 25% -> 10%
 - BMPC Plant requires improved resource, provides 4 Oil
-- Constabulary / Convict Penitentiary: `Spies in [in this city] cities act as though they have [1] levels for [Counter-intelligence]` (requires Unciv with this unique)
+- Constabulary / Convict Penitentiary: `Spies in [in this city] cities act as though they have [+1] levels for [Counter-intelligence]` (requires Unciv with this unique)
 

--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ Fork Rekmod with changes for the multiplayer games
 #### Building Changes
 - Hanse 25% -> 10%
 - BMPC Plant requires improved resource, provides 4 Oil
-- Constabulary / Convict Penitentiary: counter-intelligence spies in the city gain +1 effective level (capped at maxSpyRank; requires Unciv with this unique)
+- Constabulary / Convict Penitentiary: `Spies in [in this city] cities act as though they have [1] levels for [Counter-intelligence]` (requires Unciv with this unique)
 

--- a/README.md
+++ b/README.md
@@ -19,4 +19,5 @@ Fork Rekmod with changes for the multiplayer games
 #### Building Changes
 - Hanse 25% -> 10%
 - BMPC Plant requires improved resource, provides 4 Oil
+- Constabulary / Convict Penitentiary: counter-intelligence spies in the city gain +1 effective level (capped at maxSpyRank; requires Unciv with this unique)
 

--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -2577,7 +2577,8 @@
         "hurryCostModifier": 25,
         "uniques": [
             "Only available <when espionage is enabled>",
-            "[-25]% enemy spy effectiveness [in this city]"
+            "[-25]% enemy spy effectiveness [in this city]",
+            "[1] level(s) for counter-intelligence spies [in this city]"
         ],
         "requiredTech": "Banking"
     },
@@ -2592,7 +2593,8 @@
         "percentStatBonus": {"gold": 5,"production": 5},
         "uniques": [
             "Only available <when espionage is enabled>",
-            "[-25]% enemy spy effectiveness [in this city]"
+            "[-25]% enemy spy effectiveness [in this city]",
+            "[1] level(s) for counter-intelligence spies [in this city]"
         ],
         "requiredTech": "Machinery"
     },

--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -2578,7 +2578,7 @@
         "uniques": [
             "Only available <when espionage is enabled>",
             "[-25]% enemy spy effectiveness [in this city]",
-            "[1] level(s) for counter-intelligence spies [in this city]"
+            "Spies in [in this city] cities act as though they have [1] levels for [Counter-intelligence]"
         ],
         "requiredTech": "Banking"
     },
@@ -2594,7 +2594,7 @@
         "uniques": [
             "Only available <when espionage is enabled>",
             "[-25]% enemy spy effectiveness [in this city]",
-            "[1] level(s) for counter-intelligence spies [in this city]"
+            "Spies in [in this city] cities act as though they have [1] levels for [Counter-intelligence]"
         ],
         "requiredTech": "Machinery"
     },

--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -2578,7 +2578,7 @@
         "uniques": [
             "Only available <when espionage is enabled>",
             "[-25]% enemy spy effectiveness [in this city]",
-            "Spies in [in this city] cities act as though they have [1] levels for [Counter-intelligence]"
+            "Spies in [in this city] cities act as though they have [+1] levels for [Counter-intelligence]"
         ],
         "requiredTech": "Banking"
     },
@@ -2594,7 +2594,7 @@
         "uniques": [
             "Only available <when espionage is enabled>",
             "[-25]% enemy spy effectiveness [in this city]",
-            "Spies in [in this city] cities act as though they have [1] levels for [Counter-intelligence]"
+            "Spies in [in this city] cities act as though they have [+1] levels for [Counter-intelligence]"
         ],
         "requiredTech": "Machinery"
     },


### PR DESCRIPTION
## Кратко

- Constabulary / Convict Penitentiary: unique `Spies in [in this city] cities act as though they have [+1] levels for [Counter-intelligence]`.
- Старый эффект `[-25]% enemy spy effectiveness [in this city]` сохранён.

## Готовность к merge

- Зависимость Unciv **уже влита:** https://github.com/yairm210/Unciv/pull/15233 — **можно мержить** на Unciv с этим unique.

## План проверки

- [ ] Unciv с #15233 + этот мод: Constabulary → эффективный rank counter-intel +1.
- [ ] `[-25]%` по-прежнему на здании.