### PR TITLE
Maritime: Start bias [Coast] (Unciv ≥4.21.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ Fork Rekmod with changes for the multiplayer games
 #### Building Changes
 - Hanse 25% -> 10%
 - BMPC Plant requires improved resource, provides 4 Oil
-- Constabulary / Convict Penitentiary: `Spies in [in this city] cities act as though they have [1] levels for [Counter-intelligence]` (requires Unciv with this unique)
+- Constabulary / Convict Penitentiary: `Spies in [in this city] cities act as though they have [+1] levels for [Counter-intelligence]` (requires Unciv with this unique)
 

--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ Fork Rekmod with changes for the multiplayer games
 #### Building Changes
 - Hanse 25% -> 10%
 - BMPC Plant requires improved resource, provides 4 Oil
-- Constabulary / Convict Penitentiary: counter-intelligence spies in the city gain +1 effective level (capped at maxSpyRank; requires Unciv with this unique)
+- Constabulary / Convict Penitentiary: `Spies in [in this city] cities act as though they have [1] levels for [Counter-intelligence]` (requires Unciv with this unique)
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Fork Rekmod with changes for the multiplayer games
 - rebalance strategic resources
 - fixed startBias for Vietnam, Armenia, Aztecs, Israel, Iroqez, Canada, Ukraine, Finland, Hitties, Sweden
 - Disabled belief "Just war"
+- Maritime city-states: `Start bias [Coast]` on CityStateType (requires Unciv ≥4.21.4 / #15271)
 
 #### Building Changes
 - Hanse 25% -> 10%

--- a/README.md
+++ b/README.md
@@ -19,4 +19,5 @@ Fork Rekmod with changes for the multiplayer games
 #### Building Changes
 - Hanse 25% -> 10%
 - BMPC Plant requires improved resource, provides 4 Oil
+- Constabulary / Convict Penitentiary: counter-intelligence spies in the city gain +1 effective level (capped at maxSpyRank; requires Unciv with this unique)
 

--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -2577,7 +2577,8 @@
         "hurryCostModifier": 25,
         "uniques": [
             "Only available <when espionage is enabled>",
-            "[-25]% enemy spy effectiveness [in this city]"
+            "[-25]% enemy spy effectiveness [in this city]",
+            "[1] level(s) for counter-intelligence spies [in this city]"
         ],
         "requiredTech": "Banking"
     },
@@ -2592,7 +2593,8 @@
         "percentStatBonus": {"gold": 5,"production": 5},
         "uniques": [
             "Only available <when espionage is enabled>",
-            "[-25]% enemy spy effectiveness [in this city]"
+            "[-25]% enemy spy effectiveness [in this city]",
+            "[1] level(s) for counter-intelligence spies [in this city]"
         ],
         "requiredTech": "Machinery"
     },

--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -2578,7 +2578,7 @@
         "uniques": [
             "Only available <when espionage is enabled>",
             "[-25]% enemy spy effectiveness [in this city]",
-            "[1] level(s) for counter-intelligence spies [in this city]"
+            "Spies in [in this city] cities act as though they have [1] levels for [Counter-intelligence]"
         ],
         "requiredTech": "Banking"
     },
@@ -2594,7 +2594,7 @@
         "uniques": [
             "Only available <when espionage is enabled>",
             "[-25]% enemy spy effectiveness [in this city]",
-            "[1] level(s) for counter-intelligence spies [in this city]"
+            "Spies in [in this city] cities act as though they have [1] levels for [Counter-intelligence]"
         ],
         "requiredTech": "Machinery"
     },

--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -2578,7 +2578,7 @@
         "uniques": [
             "Only available <when espionage is enabled>",
             "[-25]% enemy spy effectiveness [in this city]",
-            "Spies in [in this city] cities act as though they have [1] levels for [Counter-intelligence]"
+            "Spies in [in this city] cities act as though they have [+1] levels for [Counter-intelligence]"
         ],
         "requiredTech": "Banking"
     },
@@ -2594,7 +2594,7 @@
         "uniques": [
             "Only available <when espionage is enabled>",
             "[-25]% enemy spy effectiveness [in this city]",
-            "Spies in [in this city] cities act as though they have [1] levels for [Counter-intelligence]"
+            "Spies in [in this city] cities act as though they have [+1] levels for [Counter-intelligence]"
         ],
         "requiredTech": "Machinery"
     },

--- a/jsons/CityStateTypes.json
+++ b/jsons/CityStateTypes.json
@@ -22,6 +22,7 @@
             "[+3 Food] [in capital]",
             "[+1 Food] [in all cities]"
         ],
+        "uniques": ["Start bias [Coast]"],
         "color": [56,255,112]
     },
     {


### PR DESCRIPTION
## Кратко

- У типа Maritime в `jsons/CityStateTypes.json` добавлен unique `Start bias [Coast]`.
- В README — пометка о зависимости от Unciv.

## Готовность к merge

- Зависимость Unciv **уже влита:** https://github.com/yairm210/Unciv/pull/15271 — **можно мержить** на Unciv ≥4.21.4.

## План проверки

- [ ] Unciv ≥4.21.4 + эта ветка: у Maritime CS чаще coastal bias.
- [ ] Остальные типы CS без изменений.
- [ ] Ruleset Validator без ошибок по unique.