### PR TITLE
Люксы: minimumWorldLuxuries (ждать Unciv #15267)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Fork Rekmod with changes for the multiplayer games
 - Project Utopia 30 -> 36
 - removed barbarian bonus on King+
 - rebalance strategic resources
+- `minimumWorldLuxuries*` ModConstants (requires Unciv https://github.com/yairm210/Unciv/pull/15267 ? do not merge until that Unciv PR lands): world luxury floors 35/60/60/88/112 by map size
 - fixed startBias for Vietnam, Armenia, Aztecs, Israel, Iroqez, Canada, Ukraine, Finland, Hitties, Sweden
 - Disabled belief "Just war"
 
 #### Building Changes
 - Hanse 25% -> 10%
 - BMPC Plant requires improved resource, provides 4 Oil
-

--- a/jsons/ModOptions.json
+++ b/jsons/ModOptions.json
@@ -11,7 +11,12 @@
         "tributeGlobalModifier": 50,
         "tributeLocalModifier": 150,
         "scoreFromPopulation": 4,
-        "scoreFromWonders": 25
+        "scoreFromWonders": 25,
+        "minimumWorldLuxuriesTiny": 35,
+        "minimumWorldLuxuriesSmall": 60,
+        "minimumWorldLuxuriesMedium": 60,
+        "minimumWorldLuxuriesLarge": 88,
+        "minimumWorldLuxuriesHuge": 112
     },
     "uniques":
             [
@@ -20,3 +25,4 @@
             ],
     "isBaseRuleset": true
 }
+


### PR DESCRIPTION
## Кратко

- В `jsons/ModOptions.json` добавлены `minimumWorldLuxuriesTiny/Small/Medium/Large/Huge` = 35/60/60/88/112.
- В README — пометка о зависимости от Unciv.

## Готовность к merge

- **Блокер (Unciv ещё open):** https://github.com/yairm210/Unciv/pull/15267 — пока не влит, константы игнорируются; **не мержить** этот PR раньше.

## План проверки

- [ ] Дождаться merge Unciv #15267 (или тестировать на его ветке).
- [ ] Новая игра с модом: random luxuries целятся в полы выше (soft / best-effort).
- [ ] Без Unciv #15267: константы игнорируются, генерация как сейчас.