### PR TITLE
CS settle-in-place: дефолт Unciv (#15268), без ModOptions unique

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Fork Rekmod with changes for the multiplayer games
 - Project Utopia 30 -> 36
 - removed barbarian bonus on King+
 - rebalance strategic resources
+- City-states settle first city in place: Unciv default since https://github.com/yairm210/Unciv/pull/15268 (no Iron ModOptions unique; do NOT add `City-states search for first city location` — that is the opt-out)
 - fixed startBias for Vietnam, Armenia, Aztecs, Israel, Iroqez, Canada, Ukraine, Finland, Hitties, Sweden
 - Disabled belief "Just war"
 
 #### Building Changes
 - Hanse 25% -> 10%
 - BMPC Plant requires improved resource, provides 4 Oil
-


### PR DESCRIPTION
## Кратко

- **Без** ModOptions unique для settle-in-place.
- Unciv сделал settle-in-place дефолтом для CS; старого opt-in `City-states found first city in place` больше нет.
- Opt-out `City-states search for first city location` Iron **не** включать.
- README это фиксирует, чтобы не вернуть мёртвый unique.

## Готовность к merge

- Зависимость Unciv **уже влита:** https://github.com/yairm210/Unciv/pull/15268 — **можно мержить** на Unciv ≥4.21.4.

## План проверки

- [ ] Unciv ≥4.21.4 + DeStup `iron2` (без CS search unique): сеттлеры CS основывают город на стартовом тайле на ходу 0/1.
- [ ] В `ModOptions.json` **нет** `City-states search for first city location`.